### PR TITLE
Fix missing semicolons

### DIFF
--- a/app/resume/embedded/page.tsx
+++ b/app/resume/embedded/page.tsx
@@ -22,5 +22,5 @@ export default function Page() {
       to pass data between threads in Python, or trying to get tkinter to display opencv2 frames. Two things which sound really easy
       but are actually really frustrating.
     </p>
-  </SkillPage>
+  </SkillPage>;
 }

--- a/app/resume/frontend/page.tsx
+++ b/app/resume/frontend/page.tsx
@@ -20,5 +20,5 @@ export default function Page() {
       and can implement designs given to me. I would like to learn the basics of design one day so that I can make nice sites on my own
       but I have higher priorities right now.
     </p>
-  </SkillPage> 
+  </SkillPage>;
 }


### PR DESCRIPTION
Forgot two semicolons after return statements. Oops