### PR TITLE
Fix `BackgroundImage` overflowing parent elements

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <div className="flex flex-col h-screen w-screen">
           <TopNav className="h-max" />
-          <div className="flex justify-center items-center flex-grow flex-shrink">
+          <div className="flex justify-center items-center flex-grow">
             {children}
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 export default function Home() {
   return (
-    <main className="flex items-center justify-center flex-shrink">
+    <main className="h-full w-full p-8 sm:p-16">
       <BackgroundImage />
     </main>
   );

--- a/app/ui/background-image.tsx
+++ b/app/ui/background-image.tsx
@@ -1,24 +1,23 @@
 "use client";
 import type { ImageInfo } from "@/app/ui/images";
+import Image from "next/image";
 import React from "react";
 
 export function BackgroundImage() {
   const image = IMAGE_INFO[Math.floor(Math.random() * IMAGE_INFO.length)];
   const title = image.titles[Math.floor(Math.random() * image.titles.length)];
 
-  // NextJS's `Image` doesn't support CSS resizing.
-  /* eslint-disable @next/next/no-img-element */
   return (
-    <div className="flex justify-center items-center max-h-full max-w-full">
-      <img
+    <div className="relative h-full w-full">
+      <Image
+        className="object-contain"
         src={image.url}
+        alt={image.alt ?? ""}
         title={title}
-        alt={image.alt}
-        className="object-contain max-h-full max-w-full"
+        fill={true}
       />
     </div>
   );
-  /* eslint-enable @next/next/no-img-element */
 }
 
 const IMAGE_INFO: ImageInfo[] = [

--- a/app/ui/topnav.tsx
+++ b/app/ui/topnav.tsx
@@ -21,7 +21,7 @@ export function TopNav({ className, ...otherProps }: TopNavProps) {
 
   return (
     <div
-      className={`flex flex-row justify-center space-x-6 bg-gray-900 h-full ${className}`}
+      className={`flex flex-row justify-center space-x-6 bg-gray-900 ${className}`}
       {...otherProps}
     >
       {NAV_LINKS.map((navLink, index) => {


### PR DESCRIPTION
Finally fixed the `BackgroundImage` overflowing the overview page.
This has been bugging me since I started this project (੭˃ᴗ˂)੭

Turns out it helps if you read the full documentation on the tools you're using. Who could've guessed?